### PR TITLE
Add RAG pipelines section with infographic

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,7 @@ import MarketGrowth from './components/MarketGrowth';
 import Competencies from './components/Competencies';
 import TechStack from './components/TechStack';
 import Challenges from './components/Challenges';
+import RAGPipelines from './components/RAGPipelines';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
       <MarketGrowth />
       <Competencies />
       <TechStack />
+      <RAGPipelines />
       <Challenges />
     </div>
   );

--- a/client/src/components/RAGPipelines.js
+++ b/client/src/components/RAGPipelines.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import Modal from './Modal';
+
+function RAGPipelines() {
+  const [modal, setModal] = useState(null);
+
+  const items = [
+    {
+      label: 'Document Ingestion',
+      pos: { top: '5%', left: '45%' },
+      color: '#FF6B6B',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Convert PDFs, databases, or feeds to embeddings.</li>
+          <li>Store vectors in a nearest-neighbor index.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Vector Index',
+      pos: { top: '40%', left: '75%' },
+      color: '#06D6A0',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Managed stores like Pinecone or Matching Engine.</li>
+          <li>Supports hybrid search and metadata filters.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Retrieval Prompt',
+      pos: { top: '80%', left: '45%' },
+      color: '#FFD166',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Embed retrieved docs into the prompt.</li>
+          <li>Ask the LLM to answer using only that context.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'LLM Generation',
+      pos: { top: '40%', left: '15%' },
+      color: '#118AB2',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Models like GPT-4 or Claude produce the final answer.</li>
+          <li>Grounded output reduces hallucinations by ~70%.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Low-Code Apps',
+      pos: { top: '10%', left: '10%' },
+      color: '#073B4C',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Tools like SageMaker Canvas or Power Apps.</li>
+          <li>Build RAG chatbots without heavy coding.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Orchestration',
+      pos: { top: '10%', left: '75%' },
+      color: '#EF476F',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Frameworks such as LangChain or CrewAI.</li>
+          <li>Manage document workflows and agents.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Monitoring',
+      pos: { top: '85%', left: '10%' },
+      color: '#8d99ae',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Prometheus and Grafana track latency.</li>
+          <li>Jaeger or X-Ray trace the full pipeline.</li>
+        </ul>
+      )
+    },
+    {
+      label: 'Security',
+      pos: { top: '85%', left: '75%' },
+      color: '#22223b',
+      content: (
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>IAM roles and network policies enforce least privilege.</li>
+          <li>Secrets stored in Vault or cloud key managers.</li>
+        </ul>
+      )
+    }
+  ];
+
+  return (
+    <section id="rag-pipelines" className="my-16">
+      <h2 className="text-3xl font-bold text-center mb-2">Retrieval-First Prompts &amp; Document Q&amp;A Pipelines</h2>
+      <p className="text-center max-w-3xl mx-auto text-[#118AB2] mb-8">
+        Retrieval-Augmented Generation combines vector search with LLMs to keep responses accurate and up to date.
+      </p>
+      <ol className="list-decimal list-inside space-y-2 text-left max-w-xl mx-auto text-[#073B4C] mb-10">
+        <li><strong>Ingest &amp; Embed Documents:</strong> convert your corpus to embeddings and store them in a vector index.</li>
+        <li><strong>Retrieve:</strong> query the index to fetch top-k relevant documents.</li>
+        <li><strong>Construct Retrieval-First Prompt:</strong> prepend the retrieved context to the user question.</li>
+        <li><strong>Generate:</strong> send the composite prompt to the LLM for a grounded answer.</li>
+      </ol>
+      <div className="relative rag-infographic mx-auto">
+        <div className="rag-ring outer-ring"></div>
+        <div className="rag-ring middle-ring"></div>
+        <div className="rag-ring inner-ring"></div>
+        {items.map((it, idx) => (
+          <button
+            key={idx}
+            className="rag-icon"
+            style={{ top: it.pos.top, left: it.pos.left, backgroundColor: it.color }}
+            onClick={() => setModal(it)}
+            aria-label={it.label}
+          >
+            {it.label.split(' ')[0]}
+          </button>
+        ))}
+      </div>
+      {modal && (
+        <Modal title={modal.label} headerColor={modal.color} onClose={() => setModal(null)}>
+          {modal.content}
+        </Modal>
+      )}
+    </section>
+  );
+}
+
+export default RAGPipelines;

--- a/client/src/components/RAGPipelines.test.js
+++ b/client/src/components/RAGPipelines.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import RAGPipelines from './RAGPipelines';
+
+test('renders RAG section heading', () => {
+  render(<RAGPipelines />);
+  const heading = screen.getByText(/Retrieval-First Prompts & Document Q&A Pipelines/i);
+  expect(heading).toBeInTheDocument();
+});

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -24,3 +24,10 @@ body { font-family: 'Inter', sans-serif; background-color: #f8fafc; /* Light gra
 .tool-title { color: #073B4C; font-weight: 600; }
 .citation { font-size: 0.75rem; color: #6b7280; font-style: italic; }
 /* Additional CSS rules from the style block, ensuring all is included */
+/* RAG infographic styles */
+.rag-infographic { width: 320px; height: 320px; position: relative; }
+.rag-ring { position: absolute; border-radius: 50%; border: 2px solid; }
+.outer-ring { width: 320px; height: 320px; border-color: #073B4C; top: 0; left: 0; }
+.middle-ring { width: 220px; height: 220px; border-color: #06D6A0; top: 50%; left: 50%; transform: translate(-50%, -50%); }
+.inner-ring { width: 120px; height: 120px; border-color: #118AB2; top: 50%; left: 50%; transform: translate(-50%, -50%); }
+.rag-icon { position: absolute; padding: 0.25rem 0.5rem; border-radius: 9999px; color: #fff; font-size: 0.75rem; cursor: pointer; }


### PR DESCRIPTION
## Summary
- introduce new `RAGPipelines` React component with interactive infographic
- wire the new component into the app
- style infographic and add tests

## Testing
- `CI=true npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840bd344014832e992f1180dc8446fb