### PR TITLE
Refactor components to use color palette

### DIFF
--- a/client/src/components/Challenges.js
+++ b/client/src/components/Challenges.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import colors from '../constants/colors';
 
 function ChallengeCard({ title, subtitle, color, sections }) {
   const [open, setOpen] = useState(false);
@@ -31,7 +32,7 @@ const challenges = [
   {
     title: 'Latency',
     subtitle: 'Optimizing models and infrastructure for real-time response.',
-    color: '#FF6B6B',
+    color: colors.coral,
     sections: {
       AWS: [
         'Bedrock latency-optimized inference cuts response times up to 50%.',
@@ -54,7 +55,7 @@ const challenges = [
   {
     title: 'Hallucination',
     subtitle: 'Implementing RAG and fine-tuning to ensure factual accuracy.',
-    color: '#FFD166',
+    color: colors.yellow,
     sections: {
       AWS: [
         'Bedrock Agents route uncertain answers to knowledge bases.',
@@ -77,7 +78,7 @@ const challenges = [
   {
     title: 'Cost Management',
     subtitle: 'Balancing performance with token usage and computational expense.',
-    color: '#06D6A0',
+    color: colors.green,
     sections: {
       AWS: [
         'Spot or Reserved Instances cut training costs up to 70%.',
@@ -101,7 +102,7 @@ const challenges = [
   {
     title: 'Scalability',
     subtitle: 'Building robust CI/CD pipelines for models serving millions of users.',
-    color: '#118AB2',
+    color: colors.blue,
     sections: {
       AWS: [
         'Multi-Model Endpoints host many models behind one endpoint.',
@@ -129,7 +130,7 @@ function Challenges() {
   return (
     <section id="challenges" className="my-16">
       <h2 className="text-3xl font-bold text-center mb-2">Solving the Toughest Challenges in Full-Stack GenAI</h2>
-      <p className="text-center max-w-3xl mx-auto text-[#118AB2] mb-8">
+      <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
         Cloud providers and prompt engineers must collaborate to overcome latency, hallucination, cost, and scalability hurdles.
       </p>
       <div className="space-y-4">

--- a/client/src/components/Competencies.js
+++ b/client/src/components/Competencies.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import colors from '../constants/colors';
 import { Doughnut } from 'react-chartjs-2';
 import { Chart, ArcElement, Tooltip, Legend } from 'chart.js';
 Chart.register(ArcElement, Tooltip, Legend);
@@ -9,7 +10,7 @@ function Competencies() {
     datasets: [
       {
         data: [35, 45, 20],
-        backgroundColor: ['#118AB2', '#06D6A0', '#FFD166'],
+        backgroundColor: [colors.blue, colors.green, colors.yellow],
       },
     ],
   };
@@ -20,7 +21,7 @@ function Competencies() {
     <section id="competencies" className="my-16">
       <div className="bg-white rounded-xl shadow-lg p-6 md:p-8">
         <h2 className="text-3xl font-bold text-center mb-2">Core Competency Breakdown</h2>
-        <p className="text-center max-w-2xl mx-auto text-[#118AB2] mb-8">
+        <p className="text-center max-w-2xl mx-auto mb-8" style={{color: colors.blue}}>
           Successful candidates are not just coders; they are multifaceted problem-solvers. The ideal profile is a blend of deep technical knowledge, process maturity, and strong business acumen.
         </p>
         <div className="chart-container h-80 md:h-96">

--- a/client/src/components/MarketGrowth.js
+++ b/client/src/components/MarketGrowth.js
@@ -1,23 +1,24 @@
 import React from 'react';
+import colors from '../constants/colors';
 
 function MarketGrowth() {
   return (
     <section id="market-growth" className="my-16">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
-          <div className="text-6xl font-extrabold text-[#FF6B6B]">300%</div>
+          <div className="text-6xl font-extrabold" style={{color: colors.coral}}>300%</div>
           <h3 className="mt-2 text-xl font-bold">Job Growth</h3>
-          <p className="mt-2 text-sm text-[#118AB2]">Projected increase in demand for Generative AI roles over the next 24 months. The market is expanding at an unprecedented rate.</p>
+          <p className="mt-2 text-sm" style={{color: colors.blue}}>Projected increase in demand for Generative AI roles over the next 24 months. The market is expanding at an unprecedented rate.</p>
         </div>
         <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
-          <div className="text-6xl font-extrabold text-[#FFD166]">$175k</div>
+          <div className="text-6xl font-extrabold" style={{color: colors.yellow}}>$175k</div>
           <h3 className="mt-2 text-xl font-bold">Median Salary</h3>
-          <p className="mt-2 text-sm text-[#118AB2]">Average starting salary for qualified engineers, reflecting the high value placed on this specialized expertise.</p>
+          <p className="mt-2 text-sm" style={{color: colors.blue}}>Average starting salary for qualified engineers, reflecting the high value placed on this specialized expertise.</p>
         </div>
         <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
-          <div className="text-6xl font-extrabold text-[#06D6A0]">Top 5</div>
+          <div className="text-6xl font-extrabold" style={{color: colors.green}}>Top 5</div>
           <h3 className="mt-2 text-xl font-bold">In-Demand Role</h3>
-          <p className="mt-2 text-sm text-[#118AB2]">Ranked among the top 5 most sought-after tech roles globally, highlighting its critical importance across industries.</p>
+          <p className="mt-2 text-sm" style={{color: colors.blue}}>Ranked among the top 5 most sought-after tech roles globally, highlighting its critical importance across industries.</p>
         </div>
       </div>
     </section>

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -1,17 +1,29 @@
 import React from 'react';
+import colors from '../constants/colors';
 
-function Modal({ title, children, onClose, headerColor = '#073B4C' }) {
-  const lightText = headerColor !== '#FFD166' && headerColor !== '#06D6A0';
-  const textClass = lightText ? 'text-white' : 'text-[#073B4C]';
+function Modal({ title, children, onClose, headerColor = colors.darkBlue }) {
+  const lightText = headerColor !== colors.yellow && headerColor !== colors.green;
+  const textColor = lightText ? colors.white : colors.darkBlue;
   return (
     <>
       <div className="modal-backdrop open" onClick={onClose}></div>
       <div className="modal-container open bg-white rounded-xl shadow-2xl flex flex-col">
-        <div className={`p-4 md:p-5 flex justify-between items-center rounded-t-xl ${textClass}`} style={{backgroundColor: headerColor}}>
+        <div
+          className="p-4 md:p-5 flex justify-between items-center rounded-t-xl"
+          style={{ backgroundColor: headerColor, color: textColor }}
+        >
           <h3 className="text-xl md:text-2xl font-bold">{title}</h3>
-          <button className={`text-2xl font-bold leading-none hover:opacity-75 ${textClass}`} onClick={onClose}>×</button>
+          <button
+            className="text-2xl font-bold leading-none hover:opacity-75"
+            onClick={onClose}
+            style={{ color: textColor }}
+          >
+            ×
+          </button>
         </div>
-        <div className="modal-content-area p-6 text-[#073B4C]">{children}</div>
+        <div className="modal-content-area p-6" style={{ color: colors.darkBlue }}>
+          {children}
+        </div>
       </div>
     </>
   );

--- a/client/src/components/RAGPipelines.js
+++ b/client/src/components/RAGPipelines.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Modal from './Modal';
+import colors from '../constants/colors';
 
 function RAGPipelines() {
   const [modal, setModal] = useState(null);
@@ -8,7 +9,7 @@ function RAGPipelines() {
     {
       label: 'Document Ingestion',
       pos: { top: '5%', left: '45%' },
-      color: '#FF6B6B',
+      color: colors.coral,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Convert PDFs, databases, or feeds to embeddings.</li>
@@ -19,7 +20,7 @@ function RAGPipelines() {
     {
       label: 'Vector Index',
       pos: { top: '40%', left: '75%' },
-      color: '#06D6A0',
+      color: colors.green,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Managed stores like Pinecone or Matching Engine.</li>
@@ -30,7 +31,7 @@ function RAGPipelines() {
     {
       label: 'Retrieval Prompt',
       pos: { top: '80%', left: '45%' },
-      color: '#FFD166',
+      color: colors.yellow,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Embed retrieved docs into the prompt.</li>
@@ -41,7 +42,7 @@ function RAGPipelines() {
     {
       label: 'LLM Generation',
       pos: { top: '40%', left: '15%' },
-      color: '#118AB2',
+      color: colors.blue,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Models like GPT-4 or Claude produce the final answer.</li>
@@ -52,7 +53,7 @@ function RAGPipelines() {
     {
       label: 'Low-Code Apps',
       pos: { top: '10%', left: '10%' },
-      color: '#073B4C',
+      color: colors.darkBlue,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Tools like SageMaker Canvas or Power Apps.</li>
@@ -63,7 +64,7 @@ function RAGPipelines() {
     {
       label: 'Orchestration',
       pos: { top: '10%', left: '75%' },
-      color: '#EF476F',
+      color: colors.magenta,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Frameworks such as LangChain or CrewAI.</li>
@@ -74,7 +75,7 @@ function RAGPipelines() {
     {
       label: 'Monitoring',
       pos: { top: '85%', left: '10%' },
-      color: '#8d99ae',
+      color: colors.gray,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>Prometheus and Grafana track latency.</li>
@@ -85,7 +86,7 @@ function RAGPipelines() {
     {
       label: 'Security',
       pos: { top: '85%', left: '75%' },
-      color: '#22223b',
+      color: colors.darkGray,
       content: (
         <ul className="list-disc list-inside space-y-1 text-sm">
           <li>IAM roles and network policies enforce least privilege.</li>
@@ -98,10 +99,10 @@ function RAGPipelines() {
   return (
     <section id="rag-pipelines" className="my-16">
       <h2 className="text-3xl font-bold text-center mb-2">Retrieval-First Prompts &amp; Document Q&amp;A Pipelines</h2>
-      <p className="text-center max-w-3xl mx-auto text-[#118AB2] mb-8">
+      <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
         Retrieval-Augmented Generation combines vector search with LLMs to keep responses accurate and up to date.
       </p>
-      <ol className="list-decimal list-inside space-y-2 text-left max-w-xl mx-auto text-[#073B4C] mb-10">
+      <ol className="list-decimal list-inside space-y-2 text-left max-w-xl mx-auto mb-10" style={{color: colors.darkBlue}}>
         <li><strong>Ingest &amp; Embed Documents:</strong> convert your corpus to embeddings and store them in a vector index.</li>
         <li><strong>Retrieve:</strong> query the index to fetch top-k relevant documents.</li>
         <li><strong>Construct Retrieval-First Prompt:</strong> prepend the retrieved context to the user question.</li>

--- a/client/src/components/TechStack.js
+++ b/client/src/components/TechStack.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { Chart, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
 import Modal from './Modal';
+import colors from '../constants/colors';
 
 Chart.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
@@ -299,32 +300,32 @@ function OrchestrationContent() {
 const categories = [
   {
     label: 'Cloud Platforms (AWS, GCP, Azure)',
-    color: '#118AB2',
+    color: colors.blue,
     content: <CloudPlatformsContent />
   },
   {
     label: 'LLMs (OpenAI, Claude, Mistral)',
-    color: '#06D6A0',
+    color: colors.green,
     content: <LLMsContent />
   },
   {
     label: 'Deployment (Docker, Kubernetes, CI/CD)',
-    color: '#FFD166',
+    color: colors.yellow,
     content: <DeploymentContent />
   },
   {
     label: 'Frameworks (PyTorch, TensorFlow)',
-    color: '#FF6B6B',
+    color: colors.coral,
     content: <FrameworksContent />
   },
   {
     label: 'Vector DBs (Pinecone, Chroma, Weaviate, Milvus, Qdrant)',
-    color: '#073B4C',
+    color: colors.darkBlue,
     content: <VectorDBsContent />
   },
   {
     label: 'Orchestration (LangChain, LangGraph, CrewAI)',
-    color: '#EF476F',
+    color: colors.magenta,
     content: <OrchestrationContent />
   }
 ];
@@ -371,8 +372,8 @@ function TechStack() {
   return (
     <section id="tech-stack-interactive" className="my-16">
       <div className="bg-white rounded-xl shadow-lg p-6 md:p-8">
-        <h2 className="text-3xl font-bold text-center mb-2 text-[#073B4C]">The Essential Tech Stack for Full-Stack GenAI</h2>
-        <p className="text-center max-w-3xl mx-auto text-[#118AB2] mb-8">
+        <h2 className="text-3xl font-bold text-center mb-2" style={{color: colors.darkBlue}}>The Essential Tech Stack for Full-Stack GenAI</h2>
+        <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
           Fluency in foundational frameworks, powerful LLMs, and robust cloud platforms is non-negotiable in 2025. Click on a bar below to explore details.
         </p>
         <div className="chart-container h-96 md:h-[500px]">

--- a/client/src/constants/colors.js
+++ b/client/src/constants/colors.js
@@ -1,0 +1,13 @@
+const colors = {
+  coral: '#FF6B6B',
+  yellow: '#FFD166',
+  green: '#06D6A0',
+  blue: '#118AB2',
+  darkBlue: '#073B4C',
+  magenta: '#EF476F',
+  gray: '#8d99ae',
+  darkGray: '#22223b',
+  white: '#FFFFFF'
+};
+
+export default colors;


### PR DESCRIPTION
## Summary
- centralize colors in `client/src/constants/colors.js`
- refactor all components to pull colors from palette

## Testing
- `npm test -- -w 1 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4447c10832eab6be415d372e8b0