### PR TITLE
Add basic component tests

### DIFF
--- a/client/src/components/__tests__/Challenges.test.js
+++ b/client/src/components/__tests__/Challenges.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import Challenges from '../Challenges';
+
+test('renders challenges heading', () => {
+  render(<Challenges />);
+  const heading = screen.getByText(/Solving the Toughest Challenges in Full-Stack GenAI/i);
+  expect(heading).toBeInTheDocument();
+});

--- a/client/src/components/__tests__/Competencies.test.js
+++ b/client/src/components/__tests__/Competencies.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import Competencies from '../Competencies';
+
+test('renders competencies heading', () => {
+  render(<Competencies />);
+  const heading = screen.getByText(/Core Competency Breakdown/i);
+  expect(heading).toBeInTheDocument();
+});

--- a/client/src/components/__tests__/MarketGrowth.test.js
+++ b/client/src/components/__tests__/MarketGrowth.test.js
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import MarketGrowth from '../MarketGrowth';
+
+test('renders key metric headings', () => {
+  render(<MarketGrowth />);
+  expect(screen.getByText(/Job Growth/i)).toBeInTheDocument();
+  expect(screen.getByText(/Median Salary/i)).toBeInTheDocument();
+  expect(screen.getByText(/In-Demand Role/i)).toBeInTheDocument();
+});

--- a/client/src/components/__tests__/TechStack.test.js
+++ b/client/src/components/__tests__/TechStack.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import TechStack from '../TechStack';
+
+test('renders tech stack heading', () => {
+  render(<TechStack />);
+  const heading = screen.getByText(/The Essential Tech Stack for Full-Stack GenAI/i);
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest/React Testing Library tests for MarketGrowth, Competencies, TechStack, and Challenges components

## Testing
- `npm test --silent --prefix client`
- `CI=true npm test --silent --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6840c445ea2c832e8c3e82f118c62134