### PR TITLE
Move RAGPipelines test

### DIFF
--- a/client/src/components/__tests__/RAGPipelines.test.js
+++ b/client/src/components/__tests__/RAGPipelines.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import RAGPipelines from './RAGPipelines';
+import RAGPipelines from '../RAGPipelines';
 
 test('renders RAG section heading', () => {
   render(<RAGPipelines />);


### PR DESCRIPTION
## Summary
- move `RAGPipelines.test.js` into the `__tests__` directory
- update import path accordingly

## Testing
- `CI=true npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6840ea05f278832ea498f0bb8699a1c6