### PR TITLE
Mock canvas in Jest setup

### DIFF
--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -3,3 +3,44 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Provide a minimal canvas context for Chart.js
+HTMLCanvasElement.prototype.getContext = jest.fn(function () {
+  return {
+    canvas: this,
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({ data: [] })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    transform: jest.fn(),
+    rect: jest.fn(),
+  clip: jest.fn(),
+  };
+});
+
+// Suppress Chart.js context warnings in test output
+const consoleError = console.error;
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation((msg, ...args) => {
+    if (typeof msg === 'string' && msg.includes("can't acquire context")) {
+      return;
+    }
+    consoleError(msg, ...args);
+  });
+});


### PR DESCRIPTION
## Summary
- create dummy canvas context in `setupTests.js`
- suppress Chart.js canvas warnings in tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840efb83d08832eb756a34cdf6f7411