### PR TITLE
Add nav, flip cards and dark mode

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,17 +5,21 @@ import Competencies from './components/Competencies';
 import TechStack from './components/TechStack';
 import Challenges from './components/Challenges';
 import RAGPipelines from './components/RAGPipelines';
+import NavBar from './components/NavBar';
 
 function App() {
   return (
-    <div className="container mx-auto px-4">
-      <h1 className="text-4xl font-bold text-center my-8 gradient-text">Industry Trends: The Modern Generative AI Engineer</h1>
-      <MarketGrowth />
-      <Competencies />
-      <TechStack />
-      <RAGPipelines />
-      <Challenges />
-    </div>
+    <>
+      <NavBar />
+      <div className="container mx-auto px-4 pt-20">
+        <h1 className="text-4xl font-bold text-center my-8 gradient-text">Industry Trends: The Modern Generative AI Engineer</h1>
+        <MarketGrowth />
+        <Competencies />
+        <TechStack />
+        <RAGPipelines />
+        <Challenges />
+      </div>
+    </>
   );
 }
 

--- a/client/src/components/Challenges.js
+++ b/client/src/components/Challenges.js
@@ -5,13 +5,13 @@ function ChallengeCard({ title, subtitle, color, sections }) {
   const [open, setOpen] = useState(false);
   const headerStyle = { backgroundColor: color };
   return (
-    <div className="mb-4 border rounded-lg shadow" onClick={() => setOpen(!open)}>
-      <div className="p-4 cursor-pointer" style={headerStyle}>
-        <h3 className="text-xl font-bold text-white">{title}</h3>
-        <p className="text-sm text-white opacity-90">{subtitle}</p>
-      </div>
-      {open && (
-        <div className="p-4 bg-white space-y-4 text-gray-700">
+    <div className="flip-card mb-4" onClick={() => setOpen(!open)}>
+      <div className={`flip-card-inner border rounded-lg shadow ${open ? 'flipped' : ''}`}>
+        <div className="flip-card-front p-4" style={headerStyle}>
+          <h3 className="text-xl font-bold text-white">{title}</h3>
+          <p className="text-sm text-white opacity-90">{subtitle}</p>
+        </div>
+        <div className="flip-card-back p-4 dark-card space-y-4 text-gray-700">
           {Object.entries(sections).map(([label, items]) => (
             <div key={label}>
               <h4 className="font-semibold">{label}</h4>
@@ -23,7 +23,7 @@ function ChallengeCard({ title, subtitle, color, sections }) {
             </div>
           ))}
         </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -130,6 +130,14 @@ function Challenges() {
   return (
     <section id="challenges" className="my-16">
       <h2 className="text-3xl font-bold text-center mb-2">Solving the Toughest Challenges in Full-Stack GenAI</h2>
+      <div className="mb-4 text-sm" style={{color: colors.blue}}>
+        <h3 className="font-semibold mb-1">What you'll learn</h3>
+        <ul className="list-disc list-inside">
+          <li>Common pain points in production</li>
+          <li>Strategies to reduce latency and hallucination</li>
+          <li>How to manage cost at scale</li>
+        </ul>
+      </div>
       <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
         Cloud providers and prompt engineers must collaborate to overcome latency, hallucination, cost, and scalability hurdles.
       </p>

--- a/client/src/components/Competencies.js
+++ b/client/src/components/Competencies.js
@@ -19,8 +19,15 @@ function Competencies() {
 
   return (
     <section id="competencies" className="my-16">
-      <div className="bg-white rounded-xl shadow-lg p-6 md:p-8">
+      <div className="card rounded-xl shadow-lg p-6 md:p-8">
         <h2 className="text-3xl font-bold text-center mb-2">Core Competency Breakdown</h2>
+        <div className="mb-4 text-sm" style={{color: colors.blue}}>
+          <h3 className="font-semibold mb-1">What you'll learn</h3>
+          <ul className="list-disc list-inside">
+            <li>Key skill categories</li>
+            <li>Importance of process and business knowledge</li>
+          </ul>
+        </div>
         <p className="text-center max-w-2xl mx-auto mb-8" style={{color: colors.blue}}>
           Successful candidates are not just coders; they are multifaceted problem-solvers. The ideal profile is a blend of deep technical knowledge, process maturity, and strong business acumen.
         </p>

--- a/client/src/components/MarketGrowth.js
+++ b/client/src/components/MarketGrowth.js
@@ -4,18 +4,26 @@ import colors from '../constants/colors';
 function MarketGrowth() {
   return (
     <section id="market-growth" className="my-16">
+      <div className="mb-4">
+        <h3 className="font-semibold mb-1">What you'll learn</h3>
+        <ul className="list-disc list-inside text-sm" style={{color: colors.blue}}>
+          <li>Hiring trends for GenAI engineers</li>
+          <li>Expected salary ranges</li>
+          <li>Overall demand across industries</li>
+        </ul>
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
+        <div className="card rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
           <div className="text-6xl font-extrabold" style={{color: colors.coral}}>300%</div>
           <h3 className="mt-2 text-xl font-bold">Job Growth</h3>
           <p className="mt-2 text-sm" style={{color: colors.blue}}>Projected increase in demand for Generative AI roles over the next 24 months. The market is expanding at an unprecedented rate.</p>
         </div>
-        <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
+        <div className="card rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
           <div className="text-6xl font-extrabold" style={{color: colors.yellow}}>$175k</div>
           <h3 className="mt-2 text-xl font-bold">Median Salary</h3>
           <p className="mt-2 text-sm" style={{color: colors.blue}}>Average starting salary for qualified engineers, reflecting the high value placed on this specialized expertise.</p>
         </div>
-        <div className="bg-white rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
+        <div className="card rounded-xl shadow-lg p-8 text-center flex flex-col justify-center items-center">
           <div className="text-6xl font-extrabold" style={{color: colors.green}}>Top 5</div>
           <h3 className="mt-2 text-xl font-bold">In-Demand Role</h3>
           <p className="mt-2 text-sm" style={{color: colors.blue}}>Ranked among the top 5 most sought-after tech roles globally, highlighting its critical importance across industries.</p>

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import colors from '../constants/colors';
 
-function Modal({ title, children, onClose, headerColor = colors.darkBlue }) {
+function Modal({ title, children, onClose, headerColor = colors.darkBlue, onPrev, onNext }) {
   const lightText = headerColor !== colors.yellow && headerColor !== colors.green;
   const textColor = lightText ? colors.white : colors.darkBlue;
   return (
     <>
       <div className="modal-backdrop open" onClick={onClose}></div>
-      <div className="modal-container open bg-white rounded-xl shadow-2xl flex flex-col">
+      <div className="modal-container open dark-card rounded-xl shadow-2xl flex flex-col">
         <div
           className="p-4 md:p-5 flex justify-between items-center rounded-t-xl"
           style={{ backgroundColor: headerColor, color: textColor }}
@@ -23,6 +23,16 @@ function Modal({ title, children, onClose, headerColor = colors.darkBlue }) {
         </div>
         <div className="modal-content-area p-6" style={{ color: colors.darkBlue }}>
           {children}
+          {(onPrev || onNext) && (
+            <div className="flex justify-between mt-6">
+              {onPrev ? (
+                <button onClick={onPrev} className="px-3 py-1 rounded bg-gray-200">Previous</button>
+              ) : <span />}
+              {onNext && (
+                <button onClick={onNext} className="px-3 py-1 rounded bg-gray-200">Next</button>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import colors from '../constants/colors';
+
+function NavBar() {
+  const [open, setOpen] = useState(false);
+  const toggle = () => setOpen(!open);
+  const links = [
+    { href: '#market-growth', label: 'Market Growth' },
+    { href: '#competencies', label: 'Core Competencies' },
+    { href: '#tech-stack-interactive', label: 'Tech Stack' },
+    { href: '#rag-pipelines', label: 'RAG Pipelines' },
+    { href: '#challenges', label: 'Challenges' },
+  ];
+  const darkToggle = () => {
+    document.body.classList.toggle('dark');
+  };
+  return (
+    <nav className="bg-white dark-card shadow-md fixed top-0 left-0 right-0 z-50">
+      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <button className="md:hidden" onClick={toggle} aria-label="Menu">
+          ☰
+        </button>
+        <ul className={`flex-col md:flex-row md:flex gap-4 ${open ? 'flex' : 'hidden'}`}
+            onClick={() => setOpen(false)}>
+          {links.map((l) => (
+            <li key={l.href}>
+              <a href={l.href} className="text-sm font-semibold" style={{color: colors.blue}}>{l.label}</a>
+            </li>
+          ))}
+          <li>
+            <button onClick={darkToggle} className="text-sm font-semibold" style={{color: colors.blue}}>
+              Toggle Dark
+            </button>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}
+
+export default NavBar;

--- a/client/src/components/RAGPipelines.js
+++ b/client/src/components/RAGPipelines.js
@@ -3,7 +3,7 @@ import Modal from './Modal';
 import colors from '../constants/colors';
 
 function RAGPipelines() {
-  const [modal, setModal] = useState(null);
+  const [modalIdx, setModalIdx] = useState(null);
 
   const items = [
     {
@@ -99,6 +99,14 @@ function RAGPipelines() {
   return (
     <section id="rag-pipelines" className="my-16">
       <h2 className="text-3xl font-bold text-center mb-2">Retrieval-First Prompts &amp; Document Q&amp;A Pipelines</h2>
+      <div className="mb-4 text-sm" style={{color: colors.blue}}>
+        <h3 className="font-semibold mb-1">What you'll learn</h3>
+        <ul className="list-disc list-inside">
+          <li>Steps to build a RAG workflow</li>
+          <li>Where vector stores fit</li>
+          <li>How orchestration ties everything together</li>
+        </ul>
+      </div>
       <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
         Retrieval-Augmented Generation combines vector search with LLMs to keep responses accurate and up to date.
       </p>
@@ -117,16 +125,22 @@ function RAGPipelines() {
             key={idx}
             className="rag-icon"
             style={{ top: it.pos.top, left: it.pos.left, backgroundColor: it.color }}
-            onClick={() => setModal(it)}
+            onClick={() => setModalIdx(idx)}
             aria-label={it.label}
           >
             {it.label.split(' ')[0]}
           </button>
         ))}
       </div>
-      {modal && (
-        <Modal title={modal.label} headerColor={modal.color} onClose={() => setModal(null)}>
-          {modal.content}
+      {modalIdx !== null && (
+        <Modal
+          title={items[modalIdx].label}
+          headerColor={items[modalIdx].color}
+          onClose={() => setModalIdx(null)}
+          onPrev={modalIdx > 0 ? () => setModalIdx(modalIdx - 1) : null}
+          onNext={modalIdx < items.length - 1 ? () => setModalIdx(modalIdx + 1) : null}
+        >
+          {items[modalIdx].content}
         </Modal>
       )}
     </section>

--- a/client/src/components/TechStack.js
+++ b/client/src/components/TechStack.js
@@ -331,7 +331,7 @@ const categories = [
 ];
 
 function TechStack() {
-  const [selected, setSelected] = useState(null);
+  const [selectedIdx, setSelectedIdx] = useState(null);
 
   const data = {
     labels: categories.map(c => c.label),
@@ -352,7 +352,7 @@ function TechStack() {
     onClick: (e, elements) => {
       if (elements.length > 0) {
         const idx = elements[0].index;
-        setSelected(categories[idx]);
+        setSelectedIdx(idx);
       }
     },
     plugins: {
@@ -371,8 +371,16 @@ function TechStack() {
 
   return (
     <section id="tech-stack-interactive" className="my-16">
-      <div className="bg-white rounded-xl shadow-lg p-6 md:p-8">
+      <div className="card rounded-xl shadow-lg p-6 md:p-8">
         <h2 className="text-3xl font-bold text-center mb-2" style={{color: colors.darkBlue}}>The Essential Tech Stack for Full-Stack GenAI</h2>
+        <div className="mb-4 text-sm" style={{color: colors.blue}}>
+          <h3 className="font-semibold mb-1">What you'll learn</h3>
+          <ul className="list-disc list-inside">
+            <li>Popular platforms and frameworks</li>
+            <li>How to orchestrate GenAI pipelines</li>
+            <li>Where to focus your learning</li>
+          </ul>
+        </div>
         <p className="text-center max-w-3xl mx-auto mb-8" style={{color: colors.blue}}>
           Fluency in foundational frameworks, powerful LLMs, and robust cloud platforms is non-negotiable in 2025. Click on a bar below to explore details.
         </p>
@@ -380,9 +388,15 @@ function TechStack() {
           <Bar data={data} options={options} />
         </div>
       </div>
-      {selected && (
-        <Modal title={selected.label} headerColor={selected.color} onClose={() => setSelected(null)}>
-          {selected.content}
+      {selectedIdx !== null && (
+        <Modal
+          title={categories[selectedIdx].label}
+          headerColor={categories[selectedIdx].color}
+          onClose={() => setSelectedIdx(null)}
+          onPrev={selectedIdx > 0 ? () => setSelectedIdx(selectedIdx - 1) : null}
+          onNext={selectedIdx < categories.length - 1 ? () => setSelectedIdx(selectedIdx + 1) : null}
+        >
+          {categories[selectedIdx].content}
         </Modal>
       )}
     </section>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,5 @@
-body { font-family: 'Inter', sans-serif; background-color: #f8fafc; /* Light gray background */ }
+body { font-family: 'Inter', sans-serif; background-color: #f8fafc; }
+body.dark { background-color: #1a202c; color: #f8fafc; }
 .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 300px; max-height: 400px; }
 #techStackBarChartCanvas { cursor: pointer; }
 @media (min-width: 768px) { .chart-container { height: 350px; } }
@@ -31,3 +32,16 @@ body { font-family: 'Inter', sans-serif; background-color: #f8fafc; /* Light gra
 .middle-ring { width: 220px; height: 220px; border-color: #06D6A0; top: 50%; left: 50%; transform: translate(-50%, -50%); }
 .inner-ring { width: 120px; height: 120px; border-color: #118AB2; top: 50%; left: 50%; transform: translate(-50%, -50%); }
 .rag-icon { position: absolute; padding: 0.25rem 0.5rem; border-radius: 9999px; color: #fff; font-size: 0.75rem; cursor: pointer; }
+
+/* Flip card styles */
+.flip-card { perspective: 1000px; }
+.flip-card-inner { position: relative; width: 100%; transition: transform 0.6s; transform-style: preserve-3d; }
+.flip-card-inner.flipped { transform: rotateY(180deg); }
+.flip-card-front, .flip-card-back { backface-visibility: hidden; width: 100%; height: 100%; position: absolute; top: 0; left: 0; }
+.flip-card-back { transform: rotateY(180deg); }
+
+/* Dark mode helpers */
+.dark-card { background-color: #ffffff; }
+body.dark .dark-card { background-color: #2d3748; color: #f8fafc; }
+.card { background-color: #ffffff; }
+body.dark .card { background-color: #2d3748; color: #f8fafc; }


### PR DESCRIPTION
## Summary
- implement fixed navigation bar with dark mode toggle
- add flip-card animation for challenges section
- insert "What you'll learn" summaries for each section
- support previous/next nav inside modals
- add dark card utility styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f6b5b704832eb739f04da030ceb5